### PR TITLE
add missing less package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jquery": "^2.2.3",
     "jshint-stylish": "^2.0.1",
     "json-loader": "^0.5.4",
+    "less": "^2.7.1",
     "lodash": "^4.11.2",
     "musical-scale-colors": "^2.0.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Addresses:

``` bash
ERROR in Cannot find module 'less'
 @ ./~/font-awesome-webpack/~/style-loader!./~/font-awesome-webpack/~/css-loader!./~/less-loader!./~/font-awesome-webpack/font-awesome-styles.loader.js!./~/font-awesome-webpack/font-awesome.config.js 4:14-144 13:2-17:4 14:20-150
```
